### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist/
 .eggs/
 doc/_build/
 .tox/
+.idea/
+.python-version


### PR DESCRIPTION
.idea/ was added because the owner of the repository uses VS Code (.vscode dir is present) and I didn't want to pollute project directory with Intellij PyCharm project files as I'm not the primary developer.
.python-version was added because I use pyenv and pyenv stores name of the local virtual environment in it. This file should not be in a repository.