### PR TITLE
Unify expect_request functions

### DIFF
--- a/tests/test_mixed.py
+++ b/tests/test_mixed.py
@@ -10,8 +10,8 @@ def _setup_oneshot(server: HTTPServer):
 
 
 def _setup_ordered(server: HTTPServer):
-    server.expect_oneshot_request("/ordered1", ordered=True).respond_with_data("OK ordered1")
-    server.expect_oneshot_request("/ordered2", ordered=True).respond_with_data("OK ordered2")
+    server.expect_ordered_request("/ordered1").respond_with_data("OK ordered1")
+    server.expect_ordered_request("/ordered2").respond_with_data("OK ordered2")
 
 
 def _setup_all(server: HTTPServer):

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -27,48 +27,6 @@ def test_oneshot(httpserver: HTTPServer):
     assert requests.get(httpserver.url_for("/foobaz")).status_code == 500
 
 
-def test_ordered_ok(httpserver: HTTPServer):
-    httpserver.expect_oneshot_request("/foobar", ordered=True).respond_with_data("OK foobar")
-    httpserver.expect_oneshot_request("/foobaz", ordered=True).respond_with_data("OK foobaz")
-
-    assert len(httpserver.ordered_handlers) == 2
-
-    # first requests should pass
-    response = requests.get(httpserver.url_for("/foobar"))
-    httpserver.check_assertions()
-    assert response.status_code == 200
-    assert response.text == "OK foobar"
-
-    response = requests.get(httpserver.url_for("/foobaz"))
-    httpserver.check_assertions()
-    assert response.status_code == 200
-    assert response.text == "OK foobaz"
-
-    assert len(httpserver.ordered_handlers) == 0
-
-    # second requests should fail due to 'oneshot' type
-    assert requests.get(httpserver.url_for("/foobar")).status_code == 500
-    assert requests.get(httpserver.url_for("/foobaz")).status_code == 500
-
-
-def test_ordered_invalid_order(httpserver: HTTPServer):
-    httpserver.expect_oneshot_request("/foobar", ordered=True).respond_with_data("OK foobar")
-    httpserver.expect_oneshot_request("/foobaz", ordered=True).respond_with_data("OK foobaz")
-
-    assert len(httpserver.ordered_handlers) == 2
-
-    # these would not pass as the order is different
-    # this mark the whole thing 'permanently failed' so no further requests must pass
-    response = requests.get(httpserver.url_for("/foobaz"))
-    assert response.status_code == 500
-
-    response = requests.get(httpserver.url_for("/foobar"))
-    assert response.status_code == 500
-
-    # as no ordered handlers are triggered yet, these must be intact..
-    assert len(httpserver.ordered_handlers) == 2
-
-
 def test_oneshot_any_method(httpserver: HTTPServer):
     for _ in range(5):
         httpserver.expect_oneshot_request("/foobar").respond_with_data("OK")

--- a/tests/test_ordered.py
+++ b/tests/test_ordered.py
@@ -1,0 +1,45 @@
+
+import requests
+from pytest_httpserver import HTTPServer
+
+
+def test_ordered_ok(httpserver: HTTPServer):
+    httpserver.expect_ordered_request("/foobar").respond_with_data("OK foobar")
+    httpserver.expect_ordered_request("/foobaz").respond_with_data("OK foobaz")
+
+    assert len(httpserver.ordered_handlers) == 2
+
+    # first requests should pass
+    response = requests.get(httpserver.url_for("/foobar"))
+    httpserver.check_assertions()
+    assert response.status_code == 200
+    assert response.text == "OK foobar"
+
+    response = requests.get(httpserver.url_for("/foobaz"))
+    httpserver.check_assertions()
+    assert response.status_code == 200
+    assert response.text == "OK foobaz"
+
+    assert len(httpserver.ordered_handlers) == 0
+
+    # second requests should fail due to 'oneshot' type
+    assert requests.get(httpserver.url_for("/foobar")).status_code == 500
+    assert requests.get(httpserver.url_for("/foobaz")).status_code == 500
+
+
+def test_ordered_invalid_order(httpserver: HTTPServer):
+    httpserver.expect_ordered_request("/foobar").respond_with_data("OK foobar")
+    httpserver.expect_ordered_request("/foobaz").respond_with_data("OK foobaz")
+
+    assert len(httpserver.ordered_handlers) == 2
+
+    # these would not pass as the order is different
+    # this mark the whole thing 'permanently failed' so no further requests must pass
+    response = requests.get(httpserver.url_for("/foobaz"))
+    assert response.status_code == 500
+
+    response = requests.get(httpserver.url_for("/foobar"))
+    assert response.status_code == 500
+
+    # as no ordered handlers are triggered yet, these must be intact..
+    assert len(httpserver.ordered_handlers) == 2


### PR DESCRIPTION
This change is not backward compatible!

1. Define enum `HandlerType`.
2. Make `expect_request` universal so that it could register permanent,
oneshot, and ordered handlers by adding enum `HandlerType` argument with
default value `HandlerType.PERMANENT`.
3. Remove ordered argument from expect_oneshot_request.
4. Add convenience method expect_ordered_request.

Fixes #9.