### PR TITLE
Include LICENSE in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include	LICENSE


### PR DESCRIPTION
The terms of the MIT license require all copies of the code to include the license text.