### PR TITLE
test_wait.py: fix tests testing exception

### DIFF
--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -30,7 +30,7 @@ def test_wait_unexpected_request(httpserver: HTTPServer):
                 requests.get(httpserver.url_for("/foobaz"))
             assert not waiting.result
         no_handler_text = 'No handler found for request'
-        assert no_handler_text in str(error)
+        assert no_handler_text in str(error.value)
 
     make_unexpected_request_and_wait()
 
@@ -49,7 +49,7 @@ def test_wait_timeout(httpserver: HTTPServer):
         assert not waiting.result
         waiting_time_error = 0.1
         assert waiting.elapsed_time == approx(waiting_timeout, abs=waiting_time_error)
-    assert 'Wait timeout occurred, but some handlers left' in str(error)
+    assert 'Wait timeout occurred, but some handlers left' in str(error.value)
 
 
 def test_wait_raise_assertion_false(httpserver: HTTPServer):


### PR DESCRIPTION
In pytest raises() returns an info object whose `value` attribute contains
the actual exception caught.

Converting to string used to work but currently it returns a string which
does not contain the exception text, so it is better to check for the actual
exception object instead.