### PR TITLE
httpserver: fix query_string type

### DIFF
--- a/releasenotes/notes/fix-16-query-string-c989bee73733a325.yaml
+++ b/releasenotes/notes/fix-16-query-string-c989bee73733a325.yaml
@@ -1,0 +1,6 @@
+---
+issues:
+  - |
+    Fixed issue \#16 by converting string object passed as query_string
+    to bytes which is the type of the query string in werkzeug, and also allowing
+    bytes as the parameter.

--- a/tests/test_querystring.py
+++ b/tests/test_querystring.py
@@ -1,0 +1,23 @@
+import requests
+from pytest import approx, raises
+
+from pytest_httpserver import HTTPServer
+
+
+def test_querystring_str(httpserver: HTTPServer):
+    httpserver.expect_request("/foobar", query_string="foo=bar", method="GET").respond_with_data(
+        "example_response"
+    )
+    response = requests.get(httpserver.url_for("/foobar?foo=bar"))
+    httpserver.check_assertions()
+    assert response.text == "example_response"
+    assert response.status_code == 200
+
+def test_querystring_bytes(httpserver: HTTPServer):
+    httpserver.expect_request("/foobar", query_string=b"foo=bar", method="GET").respond_with_data(
+        "example_response"
+    )
+    response = requests.get(httpserver.url_for("/foobar?foo=bar"))
+    httpserver.check_assertions()
+    assert response.text == "example_response"
+    assert response.status_code == 200


### PR DESCRIPTION
In werzeug the requets.query_string is a bytes object so expecting a string
in the RequestMatcher breaks the query_string matching functionality. Users
can provide a bytes object but in this case they will break the official
API.

In order to not break the API, an implicit conversion is added which
converts the string object to bytes. Accepting bytes is also added in case
the user does not want this implicit behavior.

Fixes #16