### PR TITLE
httpserver: add query matcher feature

### DIFF
--- a/tests/test_querymatcher.py
+++ b/tests/test_querymatcher.py
@@ -1,0 +1,54 @@
+from pytest_httpserver.httpserver import StringQueryMatcher, BooleanQueryMatcher, MappingQueryMatcher
+from werkzeug.datastructures import MultiDict
+
+
+def assert_match(qm, query_string):
+    values = qm.get_comparing_values(query_string)
+    assert values[0] == values[1]
+
+
+def assert_not_match(qm, query_string):
+    values = qm.get_comparing_values(query_string)
+    assert values[0] != values[1]
+
+
+def test_qm_string():
+    qm = StringQueryMatcher("k1=v1&k2=v2")
+    assert_match(qm, b"k1=v1&k2=v2")
+    assert_not_match(qm, b"k2=v2&k1=v1")
+
+
+def test_qm_bytes():
+    qm = StringQueryMatcher(b"k1=v1&k2=v2")
+    assert_match(qm, b"k1=v1&k2=v2")
+    assert_not_match(qm, b"k2=v2&k1=v1")
+
+
+def test_qm_boolean():
+    qm = BooleanQueryMatcher(True)
+    assert_match(qm, b"k1=v1")
+
+
+def test_qm_mapping_string():
+    qm = MappingQueryMatcher({"k1": "v1"})
+    assert_match(qm, b"k1=v1")
+
+
+def test_qm_mapping_unordered():
+    qm = MappingQueryMatcher({"k1": "v1", "k2": "v2"})
+    assert_match(qm, b"k1=v1&k2=v2")
+    assert_match(qm, b"k2=v2&k1=v1")
+
+
+def test_qm_mapping_first_value():
+    qm = MappingQueryMatcher({"k1": "v1"})
+    assert_match(qm, b"k1=v1&k1=v2")
+
+    qm = MappingQueryMatcher({"k1": "v2"})
+    assert_match(qm, b"k1=v2&k1=v1")
+
+
+def test_qm_mapping_multiple_values():
+    md = MultiDict([("k1", "v1"), ("k1", "v2")])
+    qm = MappingQueryMatcher(md)
+    assert_match(qm, b"k1=v1&k1=v2")

--- a/tests/test_querystring.py
+++ b/tests/test_querystring.py
@@ -21,3 +21,17 @@ def test_querystring_bytes(httpserver: HTTPServer):
     httpserver.check_assertions()
     assert response.text == "example_response"
     assert response.status_code == 200
+
+def test_querystring_dict(httpserver: HTTPServer):
+    httpserver.expect_request("/foobar", query_string={"k1": "v1", "k2": "v2"}, method="GET").respond_with_data(
+        "example_response"
+    )
+    response = requests.get(httpserver.url_for("/foobar?k1=v1&k2=v2"))
+    httpserver.check_assertions()
+    assert response.text == "example_response"
+    assert response.status_code == 200
+
+    response = requests.get(httpserver.url_for("/foobar?k2=v2&k1=v1"))
+    httpserver.check_assertions()
+    assert response.text == "example_response"
+    assert response.status_code == 200


### PR DESCRIPTION
If query_string is specified as a Mapping (dict), the query string of the
request will be parsed and will be matched with the dictionary specified.
When a key has multiple values in the request (eg. "foo=bar&foo=baz"), the
first item will be used.

If it is desired to match all the values from the same key, use
werkzeug.datastructures.MultiDict instance, as it can hold multiple values
for the same key.