### PR TITLE
travis: add 3.7 and 3.8 interpreters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "nightly"
 install:
   - pip install tox-travis


### PR DESCRIPTION
Add the latest python interpreters to the travis test suite.