### PR TITLE
httpserver: add URI matching

### DIFF
--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -40,8 +40,19 @@ Requests
 ~~~~~~~~
 When registering a :py:class:`pytest_httpserver.server.RequestMatcher`, it can use various parts
 of the HTTP request to be matched: URI, method, data, headers, and query string can be specified.
-All of these are based on simple equality checking, with the exception of method and URI where a special
-value specifying `any` can be given (variables `URI_DEFAULT` and `METHOD_ALL`, respectively).
+
+The following can be matched:
+
+* uri: a string, a regexp or an :py:class:`pytest_httpserver.server.URIPattern` object
+
+* method: GET/POST/..., specified as string
+
+* data: a string or bytes. It is possible to match with arbitrary byte data.
+
+* headers: a str-str dictionary or a :py:class:`pytest_httpserver.server.HeaderValueMatcher` object
+  which matches each header with its own provided callable
+
+* query_string: a string, bytes or a dict specifying the key-value pairs of the query string
 
 :py:class:`pytest_httpserver.server.HTTPServer` also determines how these matchers are looked up and
 what their lifetime is. You can register handlers which handle any amount of requests, but you can also

--- a/pytest_httpserver/__init__.py
+++ b/pytest_httpserver/__init__.py
@@ -8,4 +8,4 @@ This is package provides the main API for the pytest_httpserver package.
 from .httpserver import HTTPServer
 from .httpserver import HTTPServerError, Error, NoHandlerError
 from .httpserver import WaitingSettings, HeaderValueMatcher, RequestHandler
-from .httpserver import URI_DEFAULT, METHOD_ALL
+from .httpserver import URIPattern, URI_DEFAULT, METHOD_ALL

--- a/releasenotes/notes/uri-matching-dba6660cb0689402.yaml
+++ b/releasenotes/notes/uri-matching-dba6660cb0689402.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Extend URI matching by allowing to specify URIPattern object or a compiled
+    regular expression, which will be matched against the URI. URIPattern class
+    is defined as abstract in the library so the user need to implement a new
+    class based on it.

--- a/tests/test_urimatch.py
+++ b/tests/test_urimatch.py
@@ -1,0 +1,54 @@
+
+
+import re
+
+from pytest_httpserver import HTTPServer, URIPattern
+import requests
+
+
+class PrefixMatch(URIPattern):
+    def __init__(self, prefix: str):
+        self.prefix = prefix
+
+    def match(self, uri):
+        return uri.startswith(self.prefix)
+
+
+class PrefixMatchEq:
+    def __init__(self, prefix: str):
+        self.prefix = prefix
+
+    def __eq__(self, uri):
+        return uri.startswith(self.prefix)
+
+
+def test_uripattern_object(httpserver: HTTPServer):
+    httpserver.expect_request(PrefixMatch("/foo")).respond_with_json({"foo": "bar"})
+    assert requests.get(httpserver.url_for("/foo")).json() == {"foo": "bar"}
+    assert requests.get(httpserver.url_for("/foobar")).json() == {"foo": "bar"}
+    assert requests.get(httpserver.url_for("/foobaz")).json() == {"foo": "bar"}
+
+    assert requests.get(httpserver.url_for("/barfoo")).status_code == 500
+
+    assert len(httpserver.assertions) == 1
+
+
+def test_regexp(httpserver: HTTPServer):
+    httpserver.expect_request(re.compile(r"/foo/\d+/bar/")).respond_with_json({"foo": "bar"})
+    assert requests.get(httpserver.url_for("/foo/123/bar/")).json() == {"foo": "bar"}
+    assert requests.get(httpserver.url_for("/foo/9999/bar/")).json() == {"foo": "bar"}
+
+    assert requests.get(httpserver.url_for("/foo/bar/")).status_code == 500
+
+    assert len(httpserver.assertions) == 1
+
+
+def test_object_with_eq(httpserver: HTTPServer):
+    httpserver.expect_request(PrefixMatchEq("/foo")).respond_with_json({"foo": "bar"})
+    assert requests.get(httpserver.url_for("/foo")).json() == {"foo": "bar"}
+    assert requests.get(httpserver.url_for("/foobar")).json() == {"foo": "bar"}
+    assert requests.get(httpserver.url_for("/foobaz")).json() == {"foo": "bar"}
+
+    assert requests.get(httpserver.url_for("/barfoo")).status_code == 500
+
+    assert len(httpserver.assertions) == 1


### PR DESCRIPTION
Extend URI matching functionality which now accepts:

* a URIPattern object, whose match() method will be called
* a compiled regexp returned by re.compile(). In this case the
  URI will be matched against the regexp.

In both cases the URI will be an absolute path starting with a slash.

Fixes #34 and #36.