### PR TITLE
httpserver.py: make http method case-insensitive

### DIFF
--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -634,7 +634,7 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
         :param uri: URI of the request. This must be an absolute path starting with ``/``, a
             :py:class:`URIPattern` object, or a regular expression compiled by :py:func:`re.compile`.
         :param method: HTTP method of the request. If not specified (or `METHOD_ALL`
-            specified), all HTTP requests will match.
+            specified), all HTTP requests will match. Case insensitive.
         :param data: payload of the HTTP request. This could be a string (utf-8 encoded
             by default, see `data_encoding`) or a bytes object.
         :param data_encoding: the encoding used for data parameter if data is a string.
@@ -653,7 +653,7 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
 
         matcher = self.create_matcher(
             uri,
-            method=method,
+            method=method.upper(),
             data=data,
             data_encoding=data_encoding,
             headers=headers,

--- a/releasenotes/notes/http-methods-are-case-insensitive-c2a1d49f9809f263.yaml
+++ b/releasenotes/notes/http-methods-are-case-insensitive-c2a1d49f9809f263.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    HTTP methods are case insensitive. The HTTP method specified is converted to
+    uppercase in the library.

--- a/tests/test_permanent.py
+++ b/tests/test_permanent.py
@@ -41,6 +41,14 @@ def test_request_post(httpserver: HTTPServer):
     assert response.status_code == 200
 
 
+def test_request_post_case_insensitive_method(httpserver: HTTPServer):
+    httpserver.expect_request("/foobar", data='{"request": "example"}', method="post").respond_with_data("example_response")
+    response = requests.post(httpserver.url_for("/foobar"), json={"request": "example"})
+    httpserver.check_assertions()
+    assert response.text == "example_response"
+    assert response.status_code == 200
+
+
 def test_request_any_method(httpserver: HTTPServer):
     httpserver.expect_request("/foobar").respond_with_data("OK")
     response = requests.post(httpserver.url_for("/foobar"))


### PR DESCRIPTION
When creating a matcher, it should not matter whether the method is
specified as 'get' or 'GET'. At the end it will be converted to uppercase.

Fixes #40.