### PR TITLE
 Allow tests requiring multiple servers at once

### DIFF
--- a/doc/background.rst
+++ b/doc/background.rst
@@ -190,22 +190,6 @@ python versions, and tox.ini is provided if local testing is desired.
 When a bug is reported, there should be a test for it, which would re-produce
 the error and it should pass with the fix.
 
-Server starting and stopping
-----------------------------
-
-The server is started when the first test is run which uses the httpserver
-fixture. It will be running till the end of the session, and new tests will use
-the same instance. A cleanup is done between the tests which restores the clean
-state (no handlers registered, empty log, etc) to avoid cross-talk.
-
-The reason behind this is the time required to stop the server. For some reason,
-*werkzeug* (the http server used) needs about 1 second to stop itself. Adding this
-time to each test is not acceptable in most of the cases.
-
-Note that it is still compatible with *pytest-xdist* (a popular pytest extension
-to run the tests in parallel) as in such case, distinct test sessions will be
-run and those will have their own http server instance.
-
 
 Fixture scope
 -------------

--- a/pytest_httpserver/pytest_plugin.py
+++ b/pytest_httpserver/pytest_plugin.py
@@ -1,23 +1,7 @@
-
-
 import os
 
 import pytest
 from .httpserver import HTTPServer
-
-
-class Plugin:
-    SERVER = None
-
-
-class PluginHTTPServer(HTTPServer):
-    def start(self):
-        super().start()
-        Plugin.SERVER = self
-
-    def stop(self):
-        super().stop()
-        Plugin.SERVER = None
 
 
 def get_httpserver_listen_address():
@@ -36,24 +20,15 @@ def httpserver_listen_address():
 
 @pytest.fixture
 def httpserver(httpserver_listen_address):
-    if Plugin.SERVER:
-        Plugin.SERVER.clear()
-        yield Plugin.SERVER
-        return
-
     host, port = httpserver_listen_address
     if not host:
         host = HTTPServer.DEFAULT_LISTEN_HOST
     if not port:
         port = HTTPServer.DEFAULT_LISTEN_PORT
 
-    server = PluginHTTPServer(host=host, port=port)
+    server = HTTPServer(host=host, port=port)
     server.start()
-    yield server
-
-
-def pytest_sessionfinish(session, exitstatus):  # pylint: disable=unused-argument
-    if Plugin.SERVER is not None:
-        Plugin.SERVER.clear()
-        if Plugin.SERVER.is_running():
-            Plugin.SERVER.stop()
+    try:
+        yield server
+    finally:
+        server.stop()

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -1,0 +1,46 @@
+import pytest
+import requests
+
+from pytest_httpserver import HTTPServer
+
+
+@pytest.fixture
+def httpserver1():
+    host, port = ('localhost', 8001)
+    if not host:
+        host = HTTPServer.DEFAULT_LISTEN_HOST
+    if not port:
+        port = HTTPServer.DEFAULT_LISTEN_PORT
+
+    server = HTTPServer(host=host, port=port)
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+@pytest.fixture
+def httpserver2():
+    host, port = ('localhost', 9000)
+    if not host:
+        host = HTTPServer.DEFAULT_LISTEN_HOST
+    if not port:
+        port = HTTPServer.DEFAULT_LISTEN_PORT
+
+    server = HTTPServer(host=host, port=port)
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def test_multi(httpserver1: HTTPServer, httpserver2: HTTPServer):
+    assert ':8001/' in httpserver1.url_for("/foobar")
+    assert ':9000/' in httpserver2.url_for("/foobar")
+
+    httpserver1.expect_request("/foobar").respond_with_data("OK foobar 1")
+    httpserver2.expect_request("/foobar").respond_with_data("OK foobar 2")
+
+    assert "OK foobar 1" == requests.get(httpserver1.url_for("/foobar")).text
+    assert "OK foobar 2" == requests.get(httpserver2.url_for("/foobar")).text

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -19,6 +19,7 @@ def httpserver1():
     finally:
         server.stop()
 
+
 @pytest.fixture
 def httpserver2():
     host, port = ('localhost', 9000)


### PR DESCRIPTION
Remove Plugin.SERVER singleton in order to make http-server reusable

Based on the need we had we used pytest-httpserver to test multiple server instances running at once. After checking documentation and background we found that on the purpose of the single was to override start-up time on werzeuk server library. We confirmed that that is not the case anymore at least at Werkzeug==1.0.1 (so we need to update documentation too).