### PR TITLE
plugin instance as fixture + SSL support in pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ clean: cov-clean doc-clean
 .PHONY: quick-test
 quick-test:
 	.venv/bin/pytest tests -s -vv
+	.venv/bin/pytest tests -s -vv --ssl
 
 .PHONY: test
 test:
@@ -43,6 +44,7 @@ test-pdb:
 .PHONY: cov
 cov: cov-clean
 	.venv/bin/coverage run -m pytest -vv tests
+	.venv/bin/coverage run -a -m pytest -vv tests --ssl
 	.venv/bin/coverage xml
 
 .PHONY: cov-clean

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -312,7 +312,7 @@ the ``httpserver`` fixture).
 
     import pytest
 
-    @pytest.fixture
+    @pytest.fixture(scope="session")
     def httpserver_listen_address():
         return ("127.0.0.1", 8000)
 
@@ -395,7 +395,7 @@ starting/stopping the server is costly.
     import requests
 
     # setting a fixed port for httpserver
-    @pytest.fixture
+    @pytest.fixture(scope="session")
     def httpserver_listen_address():
         return ("127.0.0.1", 8000)
 

--- a/example_pytest.py
+++ b/example_pytest.py
@@ -6,7 +6,7 @@ from pytest_httpserver import HTTPServer
 
 # specify where the server should bind to
 # you can return 0 as the port, in this case it will bind to a free (ephemeral) TCP port
-@pytest.fixture
+@pytest.fixture(scope="session")
 def httpserver_listen_address():
     return ("127.0.0.1", 8000)
 

--- a/pytest_httpserver/pytest_plugin.py
+++ b/pytest_httpserver/pytest_plugin.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from pytest_httpserver import HTTPServer
+from .httpserver import HTTPServer
 
 
 def get_httpserver_listen_address():
@@ -24,7 +24,7 @@ def httpserver_ssl_context():
 
 
 @pytest.fixture(scope="session")
-def _httpserver(httpserver_listen_address, httpserver_ssl_context):
+def make_httpserver(httpserver_listen_address, httpserver_ssl_context):
     host, port = httpserver_listen_address
     if not host:
         host = HTTPServer.DEFAULT_LISTEN_HOST
@@ -40,6 +40,7 @@ def _httpserver(httpserver_listen_address, httpserver_ssl_context):
 
 
 @pytest.fixture
-def httpserver(_httpserver):
-    yield _httpserver
-    _httpserver.clear()
+def httpserver(make_httpserver):
+    server = make_httpserver
+    yield server
+    server.clear()

--- a/pytest_httpserver/pytest_plugin.py
+++ b/pytest_httpserver/pytest_plugin.py
@@ -19,14 +19,19 @@ def httpserver_listen_address():
 
 
 @pytest.fixture(scope="session")
-def _httpserver(httpserver_listen_address):
+def httpserver_ssl_context():
+    return None
+
+
+@pytest.fixture(scope="session")
+def _httpserver(httpserver_listen_address, httpserver_ssl_context):
     host, port = httpserver_listen_address
     if not host:
         host = HTTPServer.DEFAULT_LISTEN_HOST
     if not port:
         port = HTTPServer.DEFAULT_LISTEN_PORT
 
-    server = HTTPServer(host=host, port=port)
+    server = HTTPServer(host=host, port=port, ssl_context=httpserver_ssl_context)
     server.start()
     yield server
     server.clear()

--- a/pytest_httpserver/pytest_plugin.py
+++ b/pytest_httpserver/pytest_plugin.py
@@ -1,23 +1,7 @@
-
-
 import os
 
 import pytest
-from .httpserver import HTTPServer
-
-
-class Plugin:
-    SERVER = None
-
-
-class PluginHTTPServer(HTTPServer):
-    def start(self):
-        super().start()
-        Plugin.SERVER = self
-
-    def stop(self):
-        super().stop()
-        Plugin.SERVER = None
+from pytest_httpserver import HTTPServer
 
 
 def get_httpserver_listen_address():
@@ -26,34 +10,31 @@ def get_httpserver_listen_address():
     if listen_port:
         listen_port = int(listen_port)
 
-    return (listen_host, listen_port)
+    return listen_host, listen_port
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def httpserver_listen_address():
     return get_httpserver_listen_address()
 
 
-@pytest.fixture
-def httpserver(httpserver_listen_address):
-    if Plugin.SERVER:
-        Plugin.SERVER.clear()
-        yield Plugin.SERVER
-        return
-
+@pytest.fixture(scope="session")
+def _httpserver(httpserver_listen_address):
     host, port = httpserver_listen_address
     if not host:
         host = HTTPServer.DEFAULT_LISTEN_HOST
     if not port:
         port = HTTPServer.DEFAULT_LISTEN_PORT
 
-    server = PluginHTTPServer(host=host, port=port)
+    server = HTTPServer(host=host, port=port)
     server.start()
     yield server
+    server.clear()
+    if server.is_running():
+        server.stop()
 
 
-def pytest_sessionfinish(session, exitstatus):  # pylint: disable=unused-argument
-    if Plugin.SERVER is not None:
-        Plugin.SERVER.clear()
-        if Plugin.SERVER.is_running():
-            Plugin.SERVER.stop()
+@pytest.fixture
+def httpserver(_httpserver):
+    yield _httpserver
+    _httpserver.clear()

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ test=pytest
 
 [flake8]
 max-line-length = 145
+
+[tool:pytest]
+markers =
+    ssl: set up ssl context

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--ssl", action="store_true", default=False, help="run ssl tests")
+
+
+def pytest_runtest_setup(item):
+    markers = [marker.name for marker in item.iter_markers()]
+    if not item.config.getoption("--ssl") and "ssl" in markers:
+        pytest.skip()
+    if item.config.getoption("--ssl") and "ssl" not in markers:
+        pytest.skip()

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -4,6 +4,7 @@ from os.path import join as pjoin
 
 import pytest
 import requests
+pytestmark = pytest.mark.ssl
 
 test_dir = os.path.dirname(os.path.realpath(__file__))
 assets_dir = pjoin(test_dir, "assets")

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,16 +1,16 @@
-
-import ssl
 import os
+import ssl
 from os.path import join as pjoin
 
+import pytest
 import requests
-from pytest_httpserver import HTTPServer
 
 test_dir = os.path.dirname(os.path.realpath(__file__))
 assets_dir = pjoin(test_dir, "assets")
 
 
-def test_ssl():
+@pytest.fixture(scope="session")
+def httpserver_ssl_context():
     protocol = None
     for name in ("PROTOCOL_TLS_SERVER", "PROTOCOL_TLS", "PROTOCOL_TLSv1_2"):
         if hasattr(ssl, name):
@@ -19,14 +19,20 @@ def test_ssl():
 
     assert protocol is not None, "Unable to obtain TLS protocol"
 
-    context = ssl.SSLContext(protocol)
+    return ssl.SSLContext(protocol)
 
+
+def test_ssl(httpserver):
     server_crt = pjoin(assets_dir, "server.crt")
     server_key = pjoin(assets_dir, "server.key")
     root_ca = pjoin(assets_dir, "rootCA.crt")
-    context.load_cert_chain(server_crt, server_key)
+    context = httpserver.ssl_context
 
-    with HTTPServer(ssl_context=context, port=4433) as httpserver:
-        httpserver.expect_request("/foobar").respond_with_json({"foo": "bar"})
-        assert httpserver.is_running()
-        assert requests.get(httpserver.url_for("/foobar"), verify=root_ca).json() == {'foo': 'bar'}
+    assert context is not None, \
+        "SSLContext not set. The session was probably started with a test that did not define an SSLContext."
+
+    httpserver.ssl_context.load_cert_chain(server_crt, server_key)
+    httpserver.expect_request("/foobar").respond_with_json({"foo": "bar"})
+
+    assert httpserver.is_running()
+    assert requests.get(httpserver.url_for("/foobar"), verify=root_ca).json() == {'foo': 'bar'}

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,13 @@ envlist =
     py36
     py36-env
     py37
+    py38
 
 [testenv]
 commands =
     pip install -e .[test]
-    pytest
+    pytest -vv
+    pytest -vv --ssl
 
 
 [testenv:py36-env]


### PR DESCRIPTION
* Replaces the ```PluginHTTPServer``` and ```Plugin``` classes by a ```session```-scoped fixture that automatically manages the lifetime of the server instance thus removing the need for a ```pytest_sessionfinish``` hook.
* Makes sure that the server is cleaned directly after each test function and not at the start of the next test function as before. This way other test functions in the same module will not be affected by previous tests (even if they don't require the ```httpserver``` fixture)
* Adds a way to configure the SSL-context if the test function requires an HTTPS connection. This is achieved by a new fixture ```httpserver_ssl_context``` which works similarly to how the IP-address and port are configured using ```httpserver_listen_address```
* Promotes the scope of ```httpserver_listen_address``` and ```httpserver_ssl_context``` to ```session``` as changing the value returned by these fixtures after they have been used for the first time is undefined

cheers