### PR TITLE
httpserver: propagate event handler exceptions to httpserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ doc/_build/
 .tox/
 .idea/
 .python-version
+__pycache__/

--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -906,6 +906,15 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
         """
         self.assertions.append(obj)
 
+    def check(self):
+        """
+        Raises AssertionError or Errors raised in handlers.
+
+        Runs both :py:meth:`check_assertions` and :py:meth:`check_handler_errors`
+        """
+        self.check_assertions()
+        self.check_handler_errors()
+
     def check_assertions(self):
         """
         Raise AssertionError when at least one assertion added
@@ -925,6 +934,12 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
             raise AssertionError(assertion)
 
     def check_handler_errors(self):
+        """
+        Re-Raises any errors caused in request handlers
+
+        The first error raised by a handler will be re-raised here, and then
+        removed from the list.
+        """
         if self.handler_errors:
             raise self.handler_errors.pop(0)
 

--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -576,6 +576,7 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
         self.server = None
         self.server_thread = None
         self.assertions = []
+        self.handler_errors = []
         self.log = []
         self.ordered_handlers = []
         self.oneshot_handlers = RequestHandlerList()
@@ -598,6 +599,7 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
 
         """
         self.clear_assertions()
+        self.clear_handler_errors()
         self.clear_log()
         self.clear_all_handlers()
         self.permanently_failed = False
@@ -609,6 +611,13 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
         """
 
         self.assertions = []
+
+    def clear_handler_errors(self):
+        """
+        Clears the list of collected errors from handler invocations
+        """
+
+        self.handler_errors = []
 
     def clear_log(self):
         """
@@ -893,7 +902,7 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
         Assertions can be added here, and when :py:meth:`check_assertions` is called,
         it will raise AssertionError for pytest with the object specified here.
 
-        :param obj: An object which will be passed to AssertionError.
+        :param obj: An AssertionError, or an object which will be passed to an AssertionError.
         """
         self.assertions.append(obj)
 
@@ -909,7 +918,15 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
         """
 
         if self.assertions:
-            raise AssertionError(self.assertions.pop(0))
+            assertion = self.assertions.pop(0)
+            if isinstance(assertion, AssertionError):
+                raise assertion
+
+            raise AssertionError(assertion)
+
+    def check_handler_errors(self):
+        if self.handler_errors:
+            raise self.handler_errors.pop(0)
 
     def format_matchers(self) -> str:
         """
@@ -1007,7 +1024,17 @@ class HTTPServer:   # pylint: disable=too-many-instance-attributes
             if not handler:
                 return self.respond_nohandler(request)
 
-        response = handler.respond(request)
+        try:
+            response = handler.respond(request)
+        except Error:
+            # don't collect package-internal errors
+            raise
+        except AssertionError as e:
+            self.add_assertion(e)
+            raise
+        except Exception as e:
+            self.handler_errors.append(e)
+            raise
 
         if response is None:
             response = Response("")

--- a/tests/test_handler_errors.py
+++ b/tests/test_handler_errors.py
@@ -1,0 +1,67 @@
+import pytest
+import requests
+import werkzeug
+
+from pytest_httpserver import HTTPServer, Error
+
+
+def test_check_assertions_raises_handler_assertions(httpserver: HTTPServer):
+    def handler(_):
+        assert 1 == 2
+
+    httpserver.expect_request("/foobar").respond_with_handler(handler)
+
+    requests.get(httpserver.url_for("/foobar"))
+
+    with pytest.raises(AssertionError):
+        httpserver.check_assertions()
+
+    httpserver.check_handler_errors()
+
+
+def test_check_handler_errors_raises_handler_error(httpserver: HTTPServer):
+    def handler(_) -> werkzeug.Response:
+        raise ValueError("should be propagated")
+
+    httpserver.expect_request("/foobar").respond_with_handler(handler)
+
+    requests.get(httpserver.url_for("/foobar"))
+
+    httpserver.check_assertions()
+
+    with pytest.raises(ValueError):
+        httpserver.check_handler_errors()
+
+
+def test_check_handler_errors_correct_order(httpserver: HTTPServer):
+    def handler1(_) -> werkzeug.Response:
+        raise ValueError("should be propagated")
+
+    def handler2(_) -> werkzeug.Response:
+        raise OSError("should be propagated")
+
+    httpserver.expect_request("/foobar1").respond_with_handler(handler1)
+    httpserver.expect_request("/foobar2").respond_with_handler(handler2)
+
+    requests.get(httpserver.url_for("/foobar1"))
+    requests.get(httpserver.url_for("/foobar2"))
+
+    httpserver.check_assertions()
+
+    with pytest.raises(ValueError):
+        httpserver.check_handler_errors()
+
+    with pytest.raises(OSError):
+        httpserver.check_handler_errors()
+
+    httpserver.check_handler_errors()
+
+
+def test_missing_matcher_raises_exception(httpserver):
+    requests.get(httpserver.url_for("/foobar"))
+
+    # missing handlers should not raise handler exception here
+    httpserver.check_handler_errors()
+
+    with pytest.raises(AssertionError):
+        httpserver.check_assertions()


### PR DESCRIPTION
This PR fixes #63

I went for option 1 as proposed in #63 
>     * I'm thinking about the effect of adding a catch all exception handler so every exception (including AssertionError of course) would be re-raised in the check_assertions() call. But I'm unsure about how it would break the code of the users. What do you think?

The way it is implemented now should not break user code, as exceptions from handlers are collected and then re-raised.

I also added `__pycache__` to the `.gitignore`