### PR TITLE
fix pyproject.toml not to install various files into site-packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,11 @@ classifiers = [
 repository = "https://github.com/csernazs/pytest-httpserver"
 
 include = [
-    "tests",
-    "CHANGES.rst",
-    "CONTRIBUTION.md",
-    "tests/*.py",
-    "tests/assets/*",
-    "example*.py",
-    "doc",
+    { path = "tests", format = "sdist" },
+    { path = "CHANGES.rst", format = "sdist" },
+    { path = "CONTRIBUTION.md", format = "sdist" },
+    { path = "example*.py", format = "sdist" },
+    { path = "doc", format = "sdist" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Fix the `include` directives to include the specified files in sdist
only.  Without explicit format, they cause the specified files to be
included both in sdist and in wheels, which in turn means they're going
to be installed into the top-level directory of site-packages!