### PR TITLE
pytest_httpserver: extend HTTPServer to support writing behave test s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Similar to requests, you can fine-tune what response you want to send:
 - data
 
 
+#### Behave support
+
+Using the `BlockingHttpServer` class, the assertion for a request and the response can be performed in real order.
+For more info, see the [test](tests/test_blocking_http_server.py) and the API documentation.
+
+
 ### Missing features
 * HTTP/2
 * Keepalive

--- a/pytest_httpserver/__init__.py
+++ b/pytest_httpserver/__init__.py
@@ -13,8 +13,10 @@ __all__ = [
     "URIPattern",
     "URI_DEFAULT",
     "METHOD_ALL",
+    "BlockingHttpServer",
 ]
 
+from .blocking_http_server import BlockingHttpServer
 from .httpserver import METHOD_ALL
 from .httpserver import URI_DEFAULT
 from .httpserver import Error

--- a/pytest_httpserver/blocking_http_server.py
+++ b/pytest_httpserver/blocking_http_server.py
@@ -1,0 +1,155 @@
+from queue import Empty
+from queue import Queue
+from typing import Any
+from typing import Dict
+from typing import Mapping
+from typing import Optional
+from typing import Pattern
+from typing import Union
+
+from werkzeug.wrappers import Request
+from werkzeug.wrappers import Response
+
+from pytest_httpserver.httpserver import METHOD_ALL
+from pytest_httpserver.httpserver import UNDEFINED
+from pytest_httpserver.httpserver import HeaderValueMatcher
+from pytest_httpserver.httpserver import HttpServerBase
+from pytest_httpserver.httpserver import QueryMatcher
+from pytest_httpserver.httpserver import RequestHandlerBase
+from pytest_httpserver.httpserver import URIPattern
+
+
+class BlockingRequestHandler(RequestHandlerBase):
+    """
+    Provides responding to a request synchronously.
+
+    This class should only be instantiated inside the implementation of the :py:class:`BlockingHttpServer`.
+    """
+
+    def __init__(self):
+        self.response_queue = Queue()
+
+    def respond_with_response(self, response: Response):
+        self.response_queue.put_nowait(response)
+
+
+class BlockingHttpServer(HttpServerBase):
+    """
+    Server instance which enables synchronous matching for incoming requests.
+
+    :param timeout: waiting time in seconds for matching and responding to an incoming request.
+        manager
+
+    For further parameters and attributes see :py:class:`HttpServerBase`.
+    """
+
+    def __init__(self, timeout: int = 30, **kwargs):
+        super().__init__(**kwargs)
+        self.timeout = timeout
+        self.request_queue: Queue[Request] = Queue()
+        self.request_handlers: Dict[Request, Queue[BlockingRequestHandler]] = {}
+
+    def assert_request(
+        self,
+        uri: Union[str, URIPattern, Pattern[str]],
+        method: str = METHOD_ALL,
+        data: Union[str, bytes, None] = None,
+        data_encoding: str = "utf-8",
+        headers: Optional[Mapping[str, str]] = None,
+        query_string: Union[None, QueryMatcher, str, bytes, Mapping] = None,
+        header_value_matcher: Optional[HeaderValueMatcher] = None,
+        json: Any = UNDEFINED,
+        timeout: int = 30,
+    ) -> BlockingRequestHandler:
+        """
+        Wait for an incoming request and check whether it matches according to the given parameters.
+
+        If the incoming request matches, a request handler is created and registered,
+        otherwise assertion error is raised.
+        The request handler can be used once to respond for the request.
+        If no response is performed in the period given in the timeout parameter of the constructor
+        or no request arrives in the `timeout` period, assertion error is raised.
+
+        :param uri: URI of the request. This must be an absolute path starting with ``/``, a
+            :py:class:`URIPattern` object, or a regular expression compiled by :py:func:`re.compile`.
+        :param method: HTTP method of the request. If not specified (or `METHOD_ALL`
+            specified), all HTTP requests will match.
+        :param data: payload of the HTTP request. This could be a string (utf-8 encoded
+            by default, see `data_encoding`) or a bytes object.
+        :param data_encoding: the encoding used for data parameter if data is a string.
+        :param headers: dictionary of the headers of the request to be matched
+        :param query_string: the http query string, after ``?``, such as ``username=user``.
+            If string is specified it will be encoded to bytes with the encode method of
+            the string. If dict is specified, it will be matched to the ``key=value`` pairs
+            specified in the request. If multiple values specified for a given key, the first
+            value will be used. If multiple values needed to be handled, use ``MultiDict``
+            object from werkzeug.
+        :param header_value_matcher: :py:class:`HeaderValueMatcher` that matches values of headers.
+        :param json: a python object (eg. a dict) whose value will be compared to the request body after it
+            is loaded as json. If load fails, this matcher will be failed also. *Content-Type* is not checked.
+            If that's desired, add it to the headers parameter.
+        :param timeout: waiting time in seconds for an incoming request.
+
+        :return: Created and registered :py:class:`BlockingRequestHandler`.
+
+        Parameters `json` and `data` are mutually exclusive.
+        """
+
+        matcher = self.create_matcher(
+            uri,
+            method=method.upper(),
+            data=data,
+            data_encoding=data_encoding,
+            headers=headers,
+            query_string=query_string,
+            header_value_matcher=header_value_matcher,
+            json=json,
+        )
+
+        try:
+            request = self.request_queue.get(timeout=timeout)
+        except Empty:
+            raise AssertionError(f"Waiting for request {matcher} timed out")
+
+        diff = matcher.difference(request)
+
+        request_handler = BlockingRequestHandler()
+
+        self.request_handlers[request].put_nowait(request_handler)
+
+        if diff:
+            request_handler.respond_with_response(self.respond_nohandler(request))
+            raise AssertionError(f"Request {matcher} does not match: {diff}")
+
+        return request_handler
+
+    def dispatch(self, request: Request) -> Response:
+        """
+        Dispatch a request for synchronous matching.
+
+        This method queues the request for matching and waits for the request handler.
+        If there was no request handler, error is responded,
+        otherwise it waits for the response of request handler.
+        If no response arrives, assertion error is raised, otherwise the response is returned.
+
+        :param request: the request object from the werkzeug library.
+        :return: the response object what the handler responded, or a response which contains the error.
+        """
+
+        self.request_handlers[request] = Queue()
+        try:
+            self.request_queue.put_nowait(request)
+
+            try:
+                request_handler = self.request_handlers[request].get(timeout=self.timeout)
+            except Empty:
+                return self.respond_nohandler(request)
+
+            try:
+                return request_handler.response_queue.get(timeout=self.timeout)
+            except Empty:
+                assertion = AssertionError(f"No response for request: {request}")
+                self.add_assertion(assertion)
+                raise assertion
+        finally:
+            del self.request_handlers[request]

--- a/tests/test_blocking_http_server.py
+++ b/tests/test_blocking_http_server.py
@@ -1,0 +1,122 @@
+from contextlib import contextmanager
+from copy import deepcopy
+from multiprocessing.pool import ThreadPool
+from urllib.parse import urlparse
+
+import pytest
+import requests
+
+from pytest_httpserver import BlockingHttpServer
+
+
+@contextmanager
+def when_a_request_is_being_sent_to_the_server(request):
+    with ThreadPool(1) as pool:
+        yield pool.apply_async(requests.request, kwds=request)
+
+
+def then_the_server_gets_the_request(server, request):
+    request = deepcopy(request)
+    replace_url_with_uri(request)
+
+    return server.assert_request(**request)
+
+
+def replace_url_with_uri(request):
+    request["uri"] = get_uri(request["url"])
+    del request["url"]
+
+
+def get_uri(url):
+    url = urlparse(url)
+    return "?".join(item for item in [url.path, url.query] if item)
+
+
+def when_the_server_responds_to(client_connection, response):
+    client_connection.respond_with_json(response)
+
+
+def then_the_response_is_got_from(server_connection, response):
+    assert server_connection.get(timeout=9).json() == response
+
+
+@pytest.fixture
+def httpserver():
+    server = BlockingHttpServer(timeout=1)
+    server.start()
+
+    yield server
+
+    server.clear()
+    if server.is_running():
+        server.stop()
+
+
+def test_behave_workflow(httpserver: BlockingHttpServer):
+    request = dict(
+        method="GET",
+        url=httpserver.url_for("/my/path"),
+    )
+
+    with when_a_request_is_being_sent_to_the_server(request) as server_connection:
+
+        client_connection = then_the_server_gets_the_request(httpserver, request)
+
+        response = {"foo": "bar"}
+
+        when_the_server_responds_to(client_connection, response)
+
+        then_the_response_is_got_from(server_connection, response)
+
+
+def test_raises_assertion_error_when_request_does_not_match(httpserver: BlockingHttpServer):
+    request = dict(
+        method="GET",
+        url=httpserver.url_for("/my/path"),
+    )
+
+    with when_a_request_is_being_sent_to_the_server(request):
+
+        with pytest.raises(AssertionError) as exc:
+            httpserver.assert_request(uri="/not/my/path/")
+
+        assert "/not/my/path/" in str(exc)
+        assert "does not match" in str(exc)
+
+
+def test_raises_assertion_error_when_request_was_not_sent(httpserver: BlockingHttpServer):
+    with pytest.raises(AssertionError) as exc:
+        httpserver.assert_request(uri="/my/path/", timeout=1)
+
+    assert "/my/path/" in str(exc)
+    assert "timed out" in str(exc)
+
+
+def test_ignores_when_request_is_not_asserted(httpserver: BlockingHttpServer):
+    request = dict(
+        method="GET",
+        url=httpserver.url_for("/my/path"),
+    )
+
+    with when_a_request_is_being_sent_to_the_server(request) as server_connection:
+
+        assert server_connection.get(timeout=9).text == "No handler found for this request"
+
+
+def test_raises_assertion_error_when_request_was_not_responded(httpserver: BlockingHttpServer):
+    request = dict(
+        method="GET",
+        url=httpserver.url_for("/my/path"),
+    )
+
+    with when_a_request_is_being_sent_to_the_server(request):
+
+        then_the_server_gets_the_request(httpserver, request)
+
+        httpserver.stop()  # waiting for timeout of waiting for the response
+
+        with pytest.raises(AssertionError) as exc:
+            httpserver.check_assertions()
+
+        assert "/my/path" in str(exc)
+        assert "no response" in str(exc).lower()


### PR DESCRIPTION
…teps in real order

HTTPServer is suitable in itself to use in behave tests,
but because of the expectation on a request has to be done
before the request is performed
the test steps of checking the request and sending the response
also has to be before the test step triggering the request.
This makes a confusing test specification like:

Then SUT sends an other request to server
When server responds something
When a request is sent to SUT
Then SUT responds something

Using the BlockingHttpServer, the server blocks until the request is asserted
and then it blocks again until the response is performed.
The test steps can be written in real order:

When a request is sent to SUT
Then SUT sends an other request to server
When server responds something
Then SUT responds something