### PR TITLE
blocking_http_server: rename classes and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Similar to requests, you can fine-tune what response you want to send:
 #### Behave support
 
 Using the `BlockingHttpServer` class, the assertion for a request and the response can be performed in real order.
-For more info, see the [test](tests/test_blocking_http_server.py) and the API documentation.
+For more info, see the [test](tests/test_blocking_httpserver.py) and the API documentation.
 
 
 ### Missing features

--- a/pytest_httpserver/__init__.py
+++ b/pytest_httpserver/__init__.py
@@ -13,10 +13,10 @@ __all__ = [
     "URIPattern",
     "URI_DEFAULT",
     "METHOD_ALL",
-    "BlockingHttpServer",
+    "BlockingHTTPServer",
 ]
 
-from .blocking_http_server import BlockingHttpServer
+from .blocking_httpserver import BlockingHTTPServer
 from .httpserver import METHOD_ALL
 from .httpserver import URI_DEFAULT
 from .httpserver import Error

--- a/pytest_httpserver/blocking_httpserver.py
+++ b/pytest_httpserver/blocking_httpserver.py
@@ -13,7 +13,7 @@ from werkzeug.wrappers import Response
 from pytest_httpserver.httpserver import METHOD_ALL
 from pytest_httpserver.httpserver import UNDEFINED
 from pytest_httpserver.httpserver import HeaderValueMatcher
-from pytest_httpserver.httpserver import HttpServerBase
+from pytest_httpserver.httpserver import HTTPServerBase
 from pytest_httpserver.httpserver import QueryMatcher
 from pytest_httpserver.httpserver import RequestHandlerBase
 from pytest_httpserver.httpserver import URIPattern
@@ -33,7 +33,7 @@ class BlockingRequestHandler(RequestHandlerBase):
         self.response_queue.put_nowait(response)
 
 
-class BlockingHttpServer(HttpServerBase):
+class BlockingHTTPServer(HTTPServerBase):
     """
     Server instance which enables synchronous matching for incoming requests.
 

--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -567,7 +567,7 @@ class HandlerType(Enum):
     ORDERED = "ordered"
 
 
-class HttpServerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
+class HTTPServerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
     """
     Abstract HTTP server with error handling.
 
@@ -841,7 +841,7 @@ class HttpServerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
             self.stop()
 
 
-class HTTPServer(HttpServerBase):  # pylint: disable=too-many-instance-attributes
+class HTTPServer(HTTPServerBase):  # pylint: disable=too-many-instance-attributes
     """
     Server instance which manages handlers to serve pre-defined requests.
 

--- a/tests/test_blocking_httpserver.py
+++ b/tests/test_blocking_httpserver.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import pytest
 import requests
 
-from pytest_httpserver import BlockingHttpServer
+from pytest_httpserver import BlockingHTTPServer
 
 
 @contextmanager
@@ -42,7 +42,7 @@ def then_the_response_is_got_from(server_connection, response):
 
 @pytest.fixture
 def httpserver():
-    server = BlockingHttpServer(timeout=1)
+    server = BlockingHTTPServer(timeout=1)
     server.start()
 
     yield server
@@ -52,7 +52,7 @@ def httpserver():
         server.stop()
 
 
-def test_behave_workflow(httpserver: BlockingHttpServer):
+def test_behave_workflow(httpserver: BlockingHTTPServer):
     request = dict(
         method="GET",
         url=httpserver.url_for("/my/path"),
@@ -69,7 +69,7 @@ def test_behave_workflow(httpserver: BlockingHttpServer):
         then_the_response_is_got_from(server_connection, response)
 
 
-def test_raises_assertion_error_when_request_does_not_match(httpserver: BlockingHttpServer):
+def test_raises_assertion_error_when_request_does_not_match(httpserver: BlockingHTTPServer):
     request = dict(
         method="GET",
         url=httpserver.url_for("/my/path"),
@@ -84,7 +84,7 @@ def test_raises_assertion_error_when_request_does_not_match(httpserver: Blocking
         assert "does not match" in str(exc)
 
 
-def test_raises_assertion_error_when_request_was_not_sent(httpserver: BlockingHttpServer):
+def test_raises_assertion_error_when_request_was_not_sent(httpserver: BlockingHTTPServer):
     with pytest.raises(AssertionError) as exc:
         httpserver.assert_request(uri="/my/path/", timeout=1)
 
@@ -92,7 +92,7 @@ def test_raises_assertion_error_when_request_was_not_sent(httpserver: BlockingHt
     assert "timed out" in str(exc)
 
 
-def test_ignores_when_request_is_not_asserted(httpserver: BlockingHttpServer):
+def test_ignores_when_request_is_not_asserted(httpserver: BlockingHTTPServer):
     request = dict(
         method="GET",
         url=httpserver.url_for("/my/path"),
@@ -103,7 +103,7 @@ def test_ignores_when_request_is_not_asserted(httpserver: BlockingHttpServer):
         assert server_connection.get(timeout=9).text == "No handler found for this request"
 
 
-def test_raises_assertion_error_when_request_was_not_responded(httpserver: BlockingHttpServer):
+def test_raises_assertion_error_when_request_was_not_responded(httpserver: BlockingHTTPServer):
     request = dict(
         method="GET",
         url=httpserver.url_for("/my/path"),

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -137,7 +137,7 @@ def test_wheel_no_extra_contents(build: Build, version: str):
     package_contents = {path.name for path in wheel_dir.joinpath(NAME_UNDERSCORE).iterdir()}
     assert package_contents == {
         "__init__.py",
-        "blocking_http_server.py",
+        "blocking_httpserver.py",
         "httpserver.py",
         "py.typed",
         "pytest_plugin.py",
@@ -178,7 +178,7 @@ def test_sdist_contents(build: Build, version: str):
         },
         "pytest_httpserver": {
             "__init__.py",
-            "blocking_http_server.py",
+            "blocking_httpserver.py",
             "httpserver.py",
             "py.typed",
             "pytest_plugin.py",
@@ -186,7 +186,7 @@ def test_sdist_contents(build: Build, version: str):
         "tests": {
             "assets",
             "conftest.py",
-            "test_blocking_http_server.py",
+            "test_blocking_httpserver.py",
             "test_handler_errors.py",
             "test_headers.py",
             "test_json_matcher.py",


### PR DESCRIPTION
Rename 'Http' to 'HTTP' to be consistent.
Rename 'blocking_http_server.py' for the same reason.

'Http' would be a better choice but we don't want to have API
incompatibility and as HTTP is all uppercase everywhere it is better to keep
aligned with that.
