### PR TITLE
doc: fix and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Similar to requests, you can fine-tune what response you want to send:
 
 #### Behave support
 
-Using the `BlockingHttpServer` class, the assertion for a request and the response can be performed in real order.
+Using the `BlockingHTTPServer` class, the assertion for a request and the response can be performed in real order.
 For more info, see the [test](tests/test_blocking_httpserver.py) and the API documentation.
 
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -14,6 +14,29 @@ HTTPServer
 
     .. autoclass:: HTTPServer
         :members:
+        :inherited-members:
+
+RequestHandler
+~~~~~~~~~~~~~~
+
+    .. autoclass:: RequestHandler
+        :members:
+        :inherited-members:
+
+
+BlockingHTTPServer
+~~~~~~~~~~~~~~~~~~
+
+    .. autoclass:: BlockingHTTPServer
+        :members:
+        :inherited-members:
+
+BlockingRequestHandler
+~~~~~~~~~~~~~~~~~~~~~~
+
+    .. autoclass:: BlockingRequestHandler
+        :members:
+        :inherited-members:
 
 WaitingSettings
 ~~~~~~~~~~~~~~~
@@ -27,18 +50,11 @@ HeaderValueMatcher
     .. autoclass:: HeaderValueMatcher
         :members:
 
-RequestHandler
-~~~~~~~~~~~~~~
-
-    .. autoclass:: RequestHandler
-        :members:
-
 URIPattern
 ~~~~~~~~~~
 
     .. autoclass:: URIPattern
         :members:
-
 
 HTTPServerError
 ~~~~~~~~~~~~~~~
@@ -61,6 +77,9 @@ by the user.
 .. automodule:: pytest_httpserver.httpserver
 
     .. autoclass:: RequestMatcher
+        :members:
+
+    .. autoclass:: pytest_httpserver.httpserver.HTTPServerBase
         :members:
 
     .. autoclass:: pytest_httpserver.httpserver.Error

--- a/pytest_httpserver/__init__.py
+++ b/pytest_httpserver/__init__.py
@@ -14,9 +14,11 @@ __all__ = [
     "URI_DEFAULT",
     "METHOD_ALL",
     "BlockingHTTPServer",
+    "BlockingRequestHandler",
 ]
 
 from .blocking_httpserver import BlockingHTTPServer
+from .blocking_httpserver import BlockingRequestHandler
 from .httpserver import METHOD_ALL
 from .httpserver import URI_DEFAULT
 from .httpserver import Error

--- a/pytest_httpserver/blocking_httpserver.py
+++ b/pytest_httpserver/blocking_httpserver.py
@@ -24,7 +24,7 @@ class BlockingRequestHandler(RequestHandlerBase):
     """
     Provides responding to a request synchronously.
 
-    This class should only be instantiated inside the implementation of the :py:class:`BlockingHttpServer`.
+    This class should only be instantiated inside the implementation of the :py:class:`BlockingHTTPServer`.
     """
 
     def __init__(self):


### PR DESCRIPTION
Follow-up renamings, add blocking http server classes to the documentation
and fix cross-references.
