### PR TITLE
Release version 1.0.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,29 @@
 Release Notes
 =============
 
+.. _Release Notes_1.0.6:
+
+1.0.6
+=====
+
+.. _Release Notes_1.0.6_New Features:
+
+New Features
+------------
+
+- Add a new way of running tests with the blocking mode. In this mode, the
+  http server is synchronized to the main thread and the client code is run in
+  a separate thread.
+
+
+.. _Release Notes_1.0.6_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Python version classifier updated in pyproject.toml (which updates pypi also)
+
+
 .. _Release Notes_1.0.5:
 
 1.0.5

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,7 @@ author = "Zsolt Cserna"
 # built documents.
 #
 # The short X.Y version.
-version = "1.0.5"
+version = "1.0.6"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest_httpserver"
-version = "1.0.5"
+version = "1.0.6"
 description = "pytest-httpserver is a httpserver for pytest"
 authors = ["Zsolt Cserna <cserna.zsolt@gmail.com>"]
 license = "MIT"

--- a/releasenotes/notes/blocking-httpserver-3b58e2a8464b4d97.yaml
+++ b/releasenotes/notes/blocking-httpserver-3b58e2a8464b4d97.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a new way of running tests with the blocking mode. In this mode, the
+    http server is synchronized to the main thread and the client code is run in
+    a separate thread.


### PR DESCRIPTION
- release_notes: add release note about the blocking httpserver
- Version bump to 1.0.6
- CHANGES.rst: add release notes for 1.0.6
