### PR TITLE
howto: fix blocking httpserver howto

### DIFF
--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -662,10 +662,13 @@ Running httpserver in blocking mode
 In this mode, the code which is being tested (the client) is executed in a
 background thread, while the server events are synchronized to the main thread,
 so it looks like it is running in the main thread. This allows to catch the
-assertions occured on the server side synchronously, it is not needed to call
-the `check_assertions` method, assertions are raised to the main thread.
+assertions occured on the server side synchronously, and assertions are raised
+to the main thread. You need to call `check_assertions` at the end for only the
+unexpected requests.
 
-This is an experimental feature so *pytest-httpserver* has no fixture for it.
+This is an experimental feature so *pytest-httpserver* has no fixture for it
+yet. If you find this feature useful any you have ideas or suggestions related
+to this, feel free to open an issue.
 
 Example:
 

--- a/tests/test_blocking_httpserver_howto.py
+++ b/tests/test_blocking_httpserver_howto.py
@@ -20,6 +20,12 @@ def httpserver():
     if server.is_running():
         server.stop()
 
+    # this is to check if the client has made any request where no
+    # `assert_request` was called on it from the test
+
+    server.check_assertions()
+    server.clear()
+
 
 def test_simplified(httpserver: BlockingHTTPServer):
     def client(response_queue: Queue):


### PR DESCRIPTION
It is recommended to call check_assertions() at the end of the test run to
check if there were any requests made by the client which were not handled
at all.

In that case the server registers that there was an error and this needs to
be checked at the end.
