### PR TITLE
pyproject.toml: remove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Framework :: Pytest",
 ]

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -107,6 +107,15 @@ def version_to_tuple(version: str) -> Tuple:
     return tuple([int(x) for x in version.split(".")])
 
 
+def test_no_duplicate_classifiers(build: Build, pyproject):
+    pyproject_meta = pyproject["tool"]["poetry"]
+    wheel_meta = build.wheel.get_meta(version=pyproject_meta["version"])
+    classifiers = sorted(wheel_meta.get_all("Classifier"))
+    unique_classifiers = sorted(set(wheel_meta.get_all("Classifier")))
+
+    assert classifiers == unique_classifiers
+
+
 def test_python_version(build: Build, pyproject):
     pyproject_meta = pyproject["tool"]["poetry"]
     wheel_meta = build.wheel.get_meta(version=pyproject_meta["version"])


### PR DESCRIPTION

    pyproject.toml: remove classifiers
    
    Python classifiers are generated by poetry, so there's no need to specify
    them manually. Otherwise, poetry generates duplicate classifiers.
    
    Test added to avoid having duplicate classifiers in the future.