### PR TITLE
Added IPV4 and IPV6 only fixtures

### DIFF
--- a/pytest_httpserver/pytest_plugin.py
+++ b/pytest_httpserver/pytest_plugin.py
@@ -66,3 +66,37 @@ def httpserver(make_httpserver):
     server = make_httpserver
     yield server
     server.clear()
+
+
+@pytest.fixture(scope="session")
+def make_httpserver_ipv4(httpserver_ssl_context):
+    server = HTTPServer(host="127.0.0.1", port=0, ssl_context=httpserver_ssl_context)
+    server.start()
+    yield server
+    server.clear()
+    if server.is_running():
+        server.stop()
+
+
+@pytest.fixture
+def httpserver_ipv4(make_httpserver_ipv4):
+    server = make_httpserver_ipv4
+    yield server
+    server.clear()
+
+
+@pytest.fixture(scope="session")
+def make_httpserver_ipv6(httpserver_ssl_context):
+    server = HTTPServer(host="::1", port=0, ssl_context=httpserver_ssl_context)
+    server.start()
+    yield server
+    server.clear()
+    if server.is_running():
+        server.stop()
+
+
+@pytest.fixture
+def httpserver_ipv6(make_httpserver_ipv6):
+    server = make_httpserver_ipv6
+    yield server
+    server.clear()

--- a/tests/test_ip_protocols.py
+++ b/tests/test_ip_protocols.py
@@ -1,0 +1,18 @@
+import requests
+
+
+def test_ipv4(httpserver_ipv4):
+    httpserver_ipv4.expect_request("/").respond_with_data("OK")
+    assert httpserver_ipv4.host == "127.0.0.1"
+
+    response = requests.get(httpserver_ipv4.url_for("/"))
+    assert response.text == "OK"
+
+
+def test_ipv6(httpserver_ipv6):
+    httpserver_ipv6.expect_request("/").respond_with_data("OK")
+    assert httpserver_ipv6.host == "::1"
+    assert httpserver_ipv6.url_for("/") == f"http://[::1]:{httpserver_ipv6.port}/"
+
+    response = requests.get(httpserver_ipv6.url_for("/"))
+    assert response.text == "OK"

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -199,6 +199,7 @@ def test_sdist_contents(build: Build, version: str):
             "test_blocking_httpserver_howto.py",
             "test_handler_errors.py",
             "test_headers.py",
+            "test_ip_protocols.py",
             "test_json_matcher.py",
             "test_mixed.py",
             "test_oneshot.py",


### PR DESCRIPTION
This follows the discussion on #182.

I added two fixtures that forces the use of IPV4 or IPV6. I am not really happy with the code duplication, so ideas are welcome.

`url_for` had to be edited to add brackets, because `http://::1:443` is not valid, but `http://[::1]:443` is. However IPV6 should be passed to werkzeug without brackets because [some libc implementations does not support them](https://github.com/python/cpython/issues/85341#issuecomment-1253754541). The implementation could maybe have been cleaner with [urlunsplit](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlsplit) but sadly it does not support port arguments.

Tell me if the implementation looks OK, and then I will write some documentation.

Fixes #182