### PR TITLE
python deprecation

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,10 +11,6 @@ inputs:
     description: "Poetry version to use"
     required: true
 
-# outputs:
-#   random-number:
-#     description: "Random number"
-#     value: ${{ steps.random-number-generator.outputs.random-number }}
 runs:
   using: "composite"
   steps:

--- a/releasenotes/notes/python-37-deprecation-72029b78e91d6b26.yaml
+++ b/releasenotes/notes/python-37-deprecation-72029b78e91d6b26.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    Python versions earlier than 3.8 have been deprecated in order to support
+    the latest werkzeug. Users using 3.7 or earlier python may use
+    pytest-httpserver with earlier werkzeug versions but tests are no longer run
+    for these python versions.

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -78,7 +78,7 @@ class Build:
 
 
 @pytest.fixture(scope="session")
-def build(request) -> Iterable[Build]:
+def build() -> Iterable[Build]:
     dist_path = Path("dist").resolve()
     if dist_path.is_dir():
         shutil.rmtree(dist_path)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -215,9 +215,6 @@ def test_sdist_contents(build: Build, version: str):
             "test_wait.py",
             "test_with_statement.py",
         },
-        # "tests/examples": {
-        #     "test_example_blocking_httpserver.py"
-        # }
     }
 
     for subdir, subdir_content in subdir_contents.items():


### PR DESCRIPTION
- cleanup: remove comments which are not needed
- test_release.py: remove unused parameter
- releasenotes: add release note about python 3.7 deprecation
