### PR TITLE
test_example_blocking_httpserver.py: remove httpserver.clear()

### DIFF
--- a/tests/examples/test_example_blocking_httpserver.py
+++ b/tests/examples/test_example_blocking_httpserver.py
@@ -16,7 +16,6 @@ def httpserver():
 
     yield server
 
-    server.clear()
     if server.is_running():
         server.stop()
 


### PR DESCRIPTION
Remove this call as it is not needed here.
