### PR TITLE
RequestHandler: add __repr__

### DIFF
--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -560,6 +560,15 @@ class RequestHandler(RequestHandlerBase):
     def respond_with_response(self, response: Response):
         self.request_handler = lambda request: response
 
+    def __repr__(self) -> str:
+        class_name = self.__class__.__name__
+        retval = (
+            f"<{class_name} uri={self.matcher.uri!r} method={self.matcher.method!r} "
+            f"query_string={self.matcher.query_string!r} headers={self.matcher.headers!r} data={self.matcher.data!r} "
+            f"json={self.matcher.json!r}>"
+        )
+        return retval
+
 
 class RequestHandlerList(list):
     """

--- a/releasenotes/notes/requesthandler-repr-09f342f19f6250bc.yaml
+++ b/releasenotes/notes/requesthandler-repr-09f342f19f6250bc.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add ``__repr__`` to ``RequestHandler`` object so when it is compared (eg. with
+    the ``log`` attribute of the server) it will show the matcher parameters.

--- a/tests/test_permanent.py
+++ b/tests/test_permanent.py
@@ -106,3 +106,17 @@ def test_response_handler_replaced(httpserver: HTTPServer):
     response = requests.get(httpserver.url_for("/foobar"))
     assert response.json() == {"foo": "bar"}
     assert response.status_code == 200
+
+
+def test_request_handler_repr(httpserver: HTTPServer):
+    handler = httpserver.expect_request("/foo", method="POST")
+    assert (
+        repr(handler)
+        == "<RequestHandler uri='/foo' method='POST' query_string=None headers={} data=None json=<UNDEFINED>>"
+    )
+
+    handler = httpserver.expect_request("/query", query_string={"a": "123"})
+    assert (
+        repr(handler) == "<RequestHandler uri='/query' method='__ALL' query_string={'a': '123'} "
+        "headers={} data=None json=<UNDEFINED>>"
+    )


### PR DESCRIPTION
Add `__repr__` to support pytest's diff view.

Such case is when oneshot_handlers are compared with an empty list `[]`.

Fixes #273.
