### PR TITLE
HTTPServerBase: change Request to be more verbose respond_nohandler

### DIFF
--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -821,9 +821,9 @@ class HTTPServerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         As the result, there's an assertion added (which can be raised by :py:meth:`check_assertions`).
 
         """
-        text = "No handler found for request {!r}.\n".format(request)
+        text = "No handler found for request {!r} with data {!r}.".format(request, request.data)
         self.add_assertion(text + extra_message)
-        return Response("No handler found for this request", self.no_handler_status_code)
+        return Response(text + extra_message, self.no_handler_status_code)
 
     @abc.abstractmethod
     def dispatch(self, request: Request) -> Response:

--- a/tests/test_blocking_httpserver.py
+++ b/tests/test_blocking_httpserver.py
@@ -97,7 +97,10 @@ def test_ignores_when_request_is_not_asserted(httpserver: BlockingHTTPServer):
     )
 
     with when_a_request_is_being_sent_to_the_server(request) as server_connection:
-        assert server_connection.get(timeout=9).text == "No handler found for this request"
+        assert (
+            server_connection.get(timeout=9).text == "No handler found for request "
+            f"<Request 'http://localhost:{httpserver.port}/my/path' [GET]> with data b''."
+        )
 
 
 def test_raises_assertion_error_when_request_was_not_responded(httpserver: BlockingHTTPServer):


### PR DESCRIPTION
When a Request is not handled and thus triggers the nohandler, it can be very useful to have a more verbose output to indicate which Request is unhandled.

This is particularly useful when you are in a test cycle and trying to determine which requests is mismatching.