### PR TITLE
Add log querying methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ doc: dev
 doc-clean:
 	rm -rf doc/_build
 
+.PHONY: doc-clean
+doc-preview:
+	xdg-open doc/_build/html/index.html
+
 .PHONY: changes
 changes: dev
 	.venv/bin/reno report --output CHANGES.rst --no-show-source

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -24,6 +24,13 @@ RequestHandler
         :inherited-members:
 
 
+RequestMatcher
+~~~~~~~~~~~~~~
+
+    .. autoclass:: RequestMatcher
+        :members:
+
+
 BlockingHTTPServer
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,7 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", (None, "python-inv.txt")),
-    "werkzeug": ("https://werkzeug.palletsprojects.com/en/2.1.x", None),
+    "werkzeug": ("https://werkzeug.palletsprojects.com/en/3.0.x", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,6 +24,7 @@ from typing import Dict
 
 sys.path.insert(0, os.path.abspath(".."))
 
+import doc.patch
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -512,3 +512,35 @@ Example:
 
 .. literalinclude :: ../tests/examples/test_example_blocking_httpserver.py
    :language: python
+
+
+Querying the log
+----------------
+
+*pytest-httpserver* keeps a log of request-response pairs in a python list. This
+log can be accessed by the ``log`` attibute of the httpserver instance, but
+there are methods made specifically to query the log.
+
+Each of the log querying methods accepts a
+:py:class:`pytest_httpserver.RequestMatcher` object which uses the same matching
+logic which is used by the server itself. Its parameters are the same to the
+parameters specified for the server's `except_request` (and the similar) methods.
+
+The methods for querying:
+
+* :py:meth:`pytest_httpserver.HTTPServer.get_matching_requests_count` returns
+  how many requests are matching in the log as an int
+
+* :py:meth:`pytest_httpserver.HTTPServer.assert_request_made` asserts the given
+  amount of requests are matching in the log. By default it checks for one (1)
+  request but other value can be specified. For example, 0 can be specified to
+  check for requests not made.
+
+* :py:meth:`pytest_httpserver.HTTPServer.iter_matching_requests` is a generator
+  yielding Request-Response tuples of the matching entries in the log. This
+  offers greater flexibility (compared to the other methods)
+
+Example:
+
+.. literalinclude :: ../tests/examples/test_howto_log_querying.py
+   :language: python

--- a/doc/patch.py
+++ b/doc/patch.py
@@ -1,0 +1,16 @@
+# this is required to make sphinx able to find references for classes put inside
+# typing.TYPE_CHECKING block
+
+from ssl import SSLContext
+
+from werkzeug.wrappers import Request
+from werkzeug.wrappers import Response
+
+import pytest_httpserver.blocking_httpserver
+import pytest_httpserver.httpserver
+
+pytest_httpserver.httpserver.SSLContext = SSLContext
+pytest_httpserver.blocking_httpserver.SSLContext = SSLContext
+
+pytest_httpserver.blocking_httpserver.Request = Request
+pytest_httpserver.blocking_httpserver.Response = Response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ markers = [
 ]
 
 [tool.mypy]
-files = ["pytest_httpserver", "scripts", "tests", "doc"]
+files = ["pytest_httpserver", "scripts", "tests"]
 implicit_reexport = false
 
 

--- a/pytest_httpserver/__init__.py
+++ b/pytest_httpserver/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "WaitingSettings",
     "HeaderValueMatcher",
     "RequestHandler",
+    "RequestMatcher",
     "URIPattern",
     "URI_DEFAULT",
     "METHOD_ALL",
@@ -28,5 +29,6 @@ from .httpserver import HTTPServer
 from .httpserver import HTTPServerError
 from .httpserver import NoHandlerError
 from .httpserver import RequestHandler
+from .httpserver import RequestMatcher
 from .httpserver import URIPattern
 from .httpserver import WaitingSettings

--- a/releasenotes/notes/log-querying-683219f3587d2139.yaml
+++ b/releasenotes/notes/log-querying-683219f3587d2139.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    New methods added to query for matching requests in the log.

--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,14 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
 
 let
   unstable = import <nixos-unstable> { config = { allowUnfree = true; }; };
-in pkgs.mkShell {
+in
+pkgs.mkShell {
   buildInputs = with pkgs; [
     virtualenv
 
     python3Packages.tox
-    python3Packages.poetry
+    python3Packages.poetry-core
 
     pre-commit
     python3Packages.requests

--- a/tests/examples/test_howto_log_querying.py
+++ b/tests/examples/test_howto_log_querying.py
@@ -1,0 +1,56 @@
+import requests
+
+from pytest_httpserver import HTTPServer
+from pytest_httpserver import RequestMatcher
+
+
+def test_log_querying_example(httpserver: HTTPServer):
+    # set up the handler for the request
+    httpserver.expect_request("/foo").respond_with_data("OK")
+
+    # make a request matching the handler
+    assert requests.get(httpserver.url_for("/foo")).text == "OK", "Response should be 'OK'"
+
+    # make another request non-matching and handler
+    assert (
+        requests.get(httpserver.url_for("/no_match")).status_code == 500
+    ), "Response code should be 500 for non-matched requests"
+
+    # you can query the log directly
+    # log will contain all request-response pair, including non-matching
+    # requests and their response as well
+    assert len(httpserver.log) == 2, "2 request-response pairs should be in the log"
+
+    # there are the following methods to query the log
+    #
+    # each one uses the matcher we created for the handler in the very beginning
+    # of this test, RequestMatcher accepts the same parameters what you were
+    # specifying to the `expect_request` (and similar) methods.
+
+    # 1. get counts
+    # (returns 0 for non-matches)
+    httpserver.get_matching_requests_count(
+        RequestMatcher("/foo")
+    ) == 1, "There should be one request matching the the /foo request"
+
+    # 2. assert for matching request counts
+    # by default it asserts for exactly 1 matches
+    # it is roughly the same as:
+    # ```
+    # assert httpserver.get_matching_requests_count(...) == 1
+    # ```
+    # assertion text will be a fully-detailed explanation about the error, including
+    # the similar handlers (which might have been inproperly configured)
+    httpserver.assert_request_made(RequestMatcher("/foo"))
+
+    # you can also specify the counts
+    # if you want, you can specify 0 to check for non-matching requests
+
+    # there should have been 0 requests for /bar
+    httpserver.assert_request_made(RequestMatcher("/bar"), count=0)
+
+    # 3. iterate over the matching request-response pairs
+    # this provides you greater flexibility
+    for request, response in httpserver.iter_matching_requests(RequestMatcher("/foo")):
+        assert request.url == httpserver.url_for("/foo")
+        assert response.get_data() == b"OK"

--- a/tests/test_log_querying.py
+++ b/tests/test_log_querying.py
@@ -1,0 +1,73 @@
+import pytest
+import requests
+
+from pytest_httpserver import HTTPServer
+from pytest_httpserver import RequestMatcher
+
+
+def test_verify(httpserver: HTTPServer):
+    httpserver.expect_request("/foo").respond_with_data("OK")
+    httpserver.expect_request("/bar").respond_with_data("OKOK")
+
+    assert list(httpserver.iter_matching_requests(httpserver.create_matcher("/foo"))) == []
+    assert requests.get(httpserver.url_for("/foo")).text == "OK"
+    assert requests.get(httpserver.url_for("/bar")).text == "OKOK"
+
+    matching_log = list(httpserver.iter_matching_requests(httpserver.create_matcher("/foo")))
+    assert len(matching_log) == 1
+
+    request, response = matching_log[0]
+
+    assert request.url == httpserver.url_for("/foo")
+    assert response.get_data() == b"OK"
+
+    assert httpserver.get_matching_requests_count(httpserver.create_matcher("/foo")) == 1
+    httpserver.assert_request_made(httpserver.create_matcher("/foo"))
+    httpserver.assert_request_made(httpserver.create_matcher("/no_match"), count=0)
+
+    with pytest.raises(AssertionError):
+        assert httpserver.assert_request_made(httpserver.create_matcher("/no_match"))
+
+    with pytest.raises(AssertionError):
+        assert httpserver.assert_request_made(httpserver.create_matcher("/foo"), count=2)
+
+
+def test_verify_assert_msg(httpserver: HTTPServer):
+    httpserver.no_handler_status_code = 404
+    httpserver.expect_request("/foo", json={"foo": "bar"}, method="POST").respond_with_data("OK")
+    assert requests.get(httpserver.url_for("/foo"), headers={"User-Agent": "requests"}).status_code == 404
+
+    with pytest.raises(AssertionError) as err:
+        httpserver.assert_request_made(RequestMatcher("/foo", json={"foo": "bar"}, method="POST"))
+
+    expected_message = f"""Matching request found 0 times but expected 1 times.
+Expected request: <RequestMatcher uri='/foo' method='POST' query_string=None headers={{}} data=None json={{'foo': 'bar'}}>
+Found 1 similar request(s):
+--- Similar Request Start
+Path: /foo
+Method: GET
+Body: b''
+Headers: Host: localhost:{httpserver.port}\r
+User-Agent: requests\r
+Accept-Encoding: gzip, deflate\r
+Accept: */*\r
+Connection: keep-alive\r
+\r
+
+Query String: ''
+--- Similar Request End
+"""  # noqa: E501
+    assert str(err.value) == expected_message
+
+
+def test_verify_assert_msg_no_similar_requests(httpserver: HTTPServer):
+    httpserver.expect_request("/foo", json={"foo": "bar"}, method="POST").respond_with_data("OK")
+
+    with pytest.raises(AssertionError) as err:
+        httpserver.assert_request_made(RequestMatcher("/foo", json={"foo": "bar"}, method="POST"))
+
+    expected_message = """Matching request found 0 times but expected 1 times.
+Expected request: <RequestMatcher uri='/foo' method='POST' query_string=None headers={} data=None json={'foo': 'bar'}>
+No similar requests found.
+"""
+    assert str(err.value) == expected_message

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -183,6 +183,7 @@ def test_sdist_contents(build: Build, version: str):
             "howto.rst",
             "index.rst",
             "Makefile",
+            "patch.py",
             "tutorial.rst",
             "upgrade.rst",
         },

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -202,6 +202,7 @@ def test_sdist_contents(build: Build, version: str):
             "test_headers.py",
             "test_ip_protocols.py",
             "test_json_matcher.py",
+            "test_log_querying.py",
             "test_mixed.py",
             "test_oneshot.py",
             "test_ordered.py",


### PR DESCRIPTION
Add log querying methods for httpserver. This is to query if a request has been made for the server. It also allows to check if the request was made 0, 1 or more times.

The functionality is split to 3 methods for the sake of flexibility, so users who want to check for `>` or `<` relations with the numer of request matched can implement their own logic.
