### PR TITLE
.readthedocs.yml: fix rtd build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,10 +11,9 @@ build:
   jobs:
     post_create_environment:
       - pip install poetry
-      - poetry config virtualenvs.create false
 
     post_install:
-      - poetry install --with doc
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with doc
 
 sphinx:
    configuration: doc/conf.py


### PR DESCRIPTION
This time the official recommendation used:
https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry