### PR TITLE
Enable processing concurrent requests in separate threads

### DIFF
--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -220,6 +220,7 @@ def test_sdist_contents(build: Build, version: str):
             "test_querystring.py",
             "test_release.py",
             "test_ssl.py",
+            "test_threaded.py",
             "test_urimatch.py",
             "test_wait.py",
             "test_with_statement.py",

--- a/tests/test_threaded.py
+++ b/tests/test_threaded.py
@@ -1,0 +1,60 @@
+import http.client
+import threading
+import time
+from typing import Iterable
+
+import pytest
+from werkzeug.wrappers import Request
+from werkzeug.wrappers import Response
+
+from pytest_httpserver import HTTPServer
+
+
+@pytest.fixture()
+def threaded() -> Iterable[HTTPServer]:
+    server = HTTPServer(threaded=True)
+    server.start()
+    yield server
+    server.clear()
+    if server.is_running():
+        server.stop()
+
+
+def test_threaded(threaded: HTTPServer):
+    sleep_time = 0.5
+
+    def handler(_request: Request):
+        # allow some time to the client to have multiple pending request
+        # handlers running in parallel
+        time.sleep(sleep_time)
+
+        # send back thread id
+        return Response(f"{threading.get_ident()}")
+
+    threaded.expect_request("/foo").respond_with_handler(handler)
+
+    t_start = time.perf_counter()
+
+    number_of_connections = 5
+    conns = [http.client.HTTPConnection(threaded.host, threaded.port) for _ in range(number_of_connections)]
+
+    for conn in conns:
+        conn.request("GET", "/foo", headers={"Host": threaded.host})
+
+    thread_ids: list[int] = []
+    for conn in conns:
+        response = conn.getresponse()
+
+        assert response.status == 200
+        thread_ids.append(int(response.read()))
+
+    for conn in conns:
+        conn.close()
+
+    t_elapsed = time.perf_counter() - t_start
+
+    assert len(thread_ids) == len(set(thread_ids)), "thread ids returned should be unique"
+
+    assert (
+        t_elapsed < number_of_connections * sleep_time * 0.9
+    ), "elapsed time should be less than processing sequential requests"


### PR DESCRIPTION
Closes: https://github.com/csernazs/pytest-httpserver/issues/323

No risk of leaving threads behind: werkzeug.ThreadedWSGIServer uses socketserver.ThreadingMixIn, which adds a `self._threads.join()` in its `server_close`. `self._threads.join()` is called before `self.server.serve_forever()` returns, so before `self.server_thread.join()` returns, so before `self.stop()` returns.

The wording "handle concurrent requests in separate threads" was taken from the ThreadedWSGIServer documentation.
