### PR TITLE
hooks: rename with_hook to with_post_hook

### DIFF
--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -654,7 +654,7 @@ Example:
 .. literalinclude :: ../tests/examples/test_howto_custom_hooks.py
     :language: python
 
-``with_hook`` can be called multiple times, in this case *pytest-httpserver*
+``with_post_hook`` can be called multiple times, in this case *pytest-httpserver*
 will register the hooks, and hooks will be called sequentially, one by one. Each
 hook will receive the response what the previous hook returned, and the last
 hook called will return the final response which will be sent back to the client.

--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -531,7 +531,7 @@ class RequestHandler(RequestHandlerBase):
         self.request_handler: Callable[[Request], Response] | None = None
         self._hooks: list[Callable[[Request, Response], Response]] = []
 
-    def with_hook(self, hook: Callable[[Request, Response], Response]):
+    def with_post_hook(self, hook: Callable[[Request, Response], Response]):
         self._hooks.append(hook)
         return self
 

--- a/tests/examples/test_howto_custom_hooks.py
+++ b/tests/examples/test_howto_custom_hooks.py
@@ -12,6 +12,6 @@ def my_hook(_request: Request, response: Response) -> Response:
 
 
 def test_custom_hook(httpserver: HTTPServer):
-    httpserver.expect_request("/foo").with_hook(my_hook).respond_with_data(b"OK")
+    httpserver.expect_request("/foo").with_post_hook(my_hook).respond_with_data(b"OK")
 
     assert requests.get(httpserver.url_for("/foo")).headers["X-Example"] == "Example"

--- a/tests/examples/test_howto_hooks.py
+++ b/tests/examples/test_howto_hooks.py
@@ -6,6 +6,6 @@ from pytest_httpserver.hooks import Delay
 
 def test_delay(httpserver: HTTPServer):
     # this adds 0.5 seconds delay to the server response
-    httpserver.expect_request("/foo").with_hook(Delay(0.5)).respond_with_json({"example": "foo"})
+    httpserver.expect_request("/foo").with_post_hook(Delay(0.5)).respond_with_json({"example": "foo"})
 
     assert requests.get(httpserver.url_for("/foo")).json() == {"example": "foo"}


### PR DESCRIPTION
This is to make it possible to implement with_pre_hook in the future.
