### PR TITLE
tests: fix test_verify_assert_msg by setting Accept-Encoding

### DIFF
--- a/releasenotes/notes/fix-test_verify_assert_msg-af37678f187bb8da.yaml
+++ b/releasenotes/notes/fix-test_verify_assert_msg-af37678f187bb8da.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix pytest-httpserver's own tests related to log querying. No functional
+    changes in pytest-httpserver code itself. `#345 <https://github.com/csernazs/pytest-httpserver/issues/345>`_

--- a/tests/test_log_querying.py
+++ b/tests/test_log_querying.py
@@ -35,7 +35,8 @@ def test_verify(httpserver: HTTPServer):
 def test_verify_assert_msg(httpserver: HTTPServer):
     httpserver.no_handler_status_code = 404
     httpserver.expect_request("/foo", json={"foo": "bar"}, method="POST").respond_with_data("OK")
-    assert requests.get(httpserver.url_for("/foo"), headers={"User-Agent": "requests"}).status_code == 404
+    headers = {"User-Agent": "requests", "Accept-Encoding": "gzip, deflate"}
+    assert requests.get(httpserver.url_for("/foo"), headers=headers).status_code == 404
 
     with pytest.raises(AssertionError) as err:
         httpserver.assert_request_made(RequestMatcher("/foo", json={"foo": "bar"}, method="POST"))


### PR DESCRIPTION
Accept-Encoding is constructed dynamically by the availability of the
compression libraries (eg.  zstd, zstandard) so it can result failed test at
the end.

Fixes #345
