### PR TITLE
httpserver: Clear state in function-scoped fixtures before the test

### DIFF
--- a/pytest_httpserver/pytest_plugin.py
+++ b/pytest_httpserver/pytest_plugin.py
@@ -64,8 +64,8 @@ def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
 @pytest.fixture()
 def httpserver(make_httpserver):
     server = make_httpserver
-    yield server
     server.clear()
+    return server
 
 
 @pytest.fixture(scope="session")
@@ -81,8 +81,8 @@ def make_httpserver_ipv4(httpserver_ssl_context):
 @pytest.fixture()
 def httpserver_ipv4(make_httpserver_ipv4):
     server = make_httpserver_ipv4
-    yield server
     server.clear()
+    return server
 
 
 @pytest.fixture(scope="session")
@@ -98,5 +98,5 @@ def make_httpserver_ipv6(httpserver_ssl_context):
 @pytest.fixture()
 def httpserver_ipv6(make_httpserver_ipv6):
     server = make_httpserver_ipv6
-    yield server
     server.clear()
+    return server


### PR DESCRIPTION
I believe it makes sense to clear the server state **before** performing a test rather than after, starting each test in a fresh state.

Consider the following case:

```python
@fixture
def my_fixture() -> DoesSomeHTTPRequests:
    start_thread()
    yield obj
    stop_thread()

def test_function_1(my_fixture: DoesSomeHTTPRequests, httpserver: HTTPServer) -> None:
    my_fixture.make_thread_communicate_with(httpserver.url_for('/'))

def test_function_2(httpserver: HTTPServer) -> None:
    assert len(httpserver.log) == 0
```

In that case - `test_function_2` may receive leaked logs from `test_function_1` since `my_fixture` is destructed only **after** `httpserver` and therefore the fixture would be able to send requests to the server **after** the state is cleared.

One could argue that swapping the fixtures order would solve this, but in real world scenarios fixtures can be nested and far too complex to have a well defined order for cases like that. I think that clearing the state before the test is a simple and less error prone solution.