### PR TITLE
Where available, use tomllib from the standard library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           type: test
-          python-version: "3.10"
+          python-version: "3.11"
           poetry-version: ${{ env.POETRY_VERSION }}
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1119,17 +1119,6 @@ lint = ["docutils-stubs", "flake8", "mypy"]
 test = ["pytest"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1153,17 +1142,6 @@ files = [
 
 [package.dependencies]
 urllib3 = ">=2"
-
-[[package]]
-name = "types-toml"
-version = "0.10.8.20240310"
-description = "Typing stubs for toml"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "types-toml-0.10.8.20240310.tar.gz", hash = "sha256:3d41501302972436a6b8b239c850b26689657e25281b48ff0ec06345b8830331"},
-    {file = "types_toml-0.10.8.20240310-py3-none-any.whl", hash = "sha256:627b47775d25fa29977d9c70dc0cbab3f314f32c8d8d0c012f2ef5de7aaec05d"},
-]
 
 [[package]]
 name = "typing-extensions"
@@ -1252,4 +1230,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "18d0dd17a1251f60010663c6207d501ccaa4e2d9eef501442368d882eb8b0fd0"
+content-hash = "e38e6c3ea41fc469f576f96df8af75ccb2d3d5f1bbd2c4d7e3727e13a13f5789"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,7 @@ types-requests = "*"
 pytest = ">=7.1.3,<9.0.0"
 pytest-cov = ">=3,<6"
 coverage = ">=6.4.4,<8.0.0"
-types-toml = "*"
-toml = "^0.10.2"
+tomli = { version = "*", markers = "python_version < '3.11'"}
 black = "*"
 ruff = "*"
 mypy = "*"
@@ -72,8 +71,7 @@ coverage = "*"
 requests = "*"
 types-requests = "*"
 pre-commit = "*"
-types-toml = "*"
-toml = "*"
+tomli = { version = "*", markers = "python_version < '3.11'"}
 mypy = "*"
 
 [build-system]

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -11,7 +11,13 @@ from pathlib import Path
 from typing import Iterable
 
 import pytest
-import toml
+
+try:
+    import tomllib
+except ImportError:
+    # Unfortunately mypy cannot handle this try/expect pattern, and "type: ignore"
+    # is the simplest work-around. See: https://github.com/python/mypy/issues/1153
+    import tomli as tomllib  # type: ignore
 
 # TODO: skip if poetry is not available or add mark to test it explicitly
 
@@ -31,8 +37,8 @@ def pyproject_path() -> Path:
 @pytest.fixture(scope="session")
 def pyproject(pyproject_path: Path):
     assert pyproject_path.is_file()
-    with pyproject_path.open() as infile:
-        pyproject = toml.load(infile)
+    with pyproject_path.open("rb") as infile:
+        pyproject = tomllib.load(infile)
     return pyproject
 
 


### PR DESCRIPTION
Fallback to tomli, which is the same project,
rather than toml which wasn't updated for a while.