### PR TITLE
Configurable expect method

### DIFF
--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -972,6 +972,22 @@ class HTTPServer(HTTPServerBase):  # pylint: disable=too-many-instance-attribute
         self.oneshot_handlers = RequestHandlerList()
         self.handlers = RequestHandlerList()
 
+    def expect(self, matcher: RequestMatcher, handler_type: HandlerType = HandlerType.PERMANENT) -> RequestHandler:
+        """
+        Create and register a request handler.
+
+        :param matcher: :py:class:`RequestMatcher` used to match requests.
+        :param handler_type: type of handler
+        """
+        request_handler = RequestHandler(matcher)
+        if handler_type == HandlerType.PERMANENT:
+            self.handlers.append(request_handler)
+        elif handler_type == HandlerType.ONESHOT:
+            self.oneshot_handlers.append(request_handler)
+        elif handler_type == HandlerType.ORDERED:
+            self.ordered_handlers.append(request_handler)
+        return request_handler
+
     def expect_request(
         self,
         uri: str | URIPattern | Pattern[str],

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,0 +1,11 @@
+import requests
+
+from pytest_httpserver import HTTPServer
+
+
+def test_expect_method(httpserver: HTTPServer):
+    expected_response = "OK"
+    matcher = httpserver.create_matcher(uri="/test", method="POST")
+    httpserver.expect(matcher).respond_with_data(expected_response)
+    resp = requests.post(httpserver.url_for("/test"), json={"list": [1, 2, 3, 4]})
+    assert resp.text == expected_response

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -234,6 +234,7 @@ def test_sdist_contents(build: Build, version: str):
             "test_urimatch.py",
             "test_wait.py",
             "test_with_statement.py",
+            "test_matcher.py",
         },
     }
 


### PR DESCRIPTION
I wasn't able to match a request I was making and it turned out that I was serializing a set, and therefore wouldn't know the order of the JSON list that gets serialized. Due to the way JSON is compared in this library, order does matter (even if you pass a structure with a set to `json=`).

So I think it makes sense to allow passing in some sort of open interface or simply accept RequestMatcher and consumers could override methods.

This would allow composing RequestMatcher with [deepdiff](https://github.com/seperman/deepdiff) to do order insensitive matching or *anything* else you'd want to do.