### PR TITLE
prevent shutdown issues by making server thread daemonic

### DIFF
--- a/pytest_httpserver/httpserver.py
+++ b/pytest_httpserver/httpserver.py
@@ -770,7 +770,8 @@ class HTTPServerBase(abc.ABC):  # pylint: disable=too-many-instance-attributes
         )
 
         self.port = self.server.port  # Update port (needed if `port` was set to 0)
-        self.server_thread = threading.Thread(target=self.thread_target)
+        # Explicitly make the new thread daemonic to avoid shutdown issues
+        self.server_thread = threading.Thread(target=self.thread_target, daemon=True)
         self.server_thread.start()
 
     def stop(self):

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -233,6 +233,7 @@ def test_sdist_contents(build: Build, version: str):
             "test_querystring.py",
             "test_release.py",
             "test_ssl.py",
+            "test_thread_type.py",
             "test_threaded.py",
             "test_urimatch.py",
             "test_wait.py",

--- a/tests/test_thread_type.py
+++ b/tests/test_thread_type.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+import requests
+from werkzeug import Response
+
+if TYPE_CHECKING:
+    from werkzeug import Request
+
+    from pytest_httpserver import HTTPServer
+
+
+def test_server_thread_is_daemon(httpserver: HTTPServer):
+    def handler(_request: Request):
+        return Response(f"{threading.current_thread().daemon}")
+
+    httpserver.expect_request("/foo").respond_with_handler(handler)
+
+    assert requests.get(httpserver.url_for("/foo")).text == "True"


### PR DESCRIPTION
## Motivation
In the [LocalStack](https://github.com/localstack/localstack/) test codebase we heavily use LocalStack to test integrations of our emulated AWS services. Thanks for the great project!
In the past we were facing issues with our integration tests timing out due to shutdowns being blocked. It turns out that some of the `pytest-httpserver` threads were not properly shut down. @bentsku fixed this by patching the `HTTPServer` class to spawn a deamon thread to make sure that it cannot block the shutdown of the interpreter with https://github.com/localstack/localstack/pull/10052.
This patch broke with the latest release, as the `start` method was modified (which is why we did not upgrade to the latest version 1.1.2, but introduced an upper limit with https://github.com/localstack/localstack/pull/12303/commits/01a97ba1fa8619da6266815f88c542f7ea952011).

This PR aims at fixing these issues upstream to prevent issues like this for other users, as well as to be able to remove the patch in our projects.

## Changes
- Makes the server thread daemonic.
- Adds a test to ensure that request handlers are executed on daemonic threads.